### PR TITLE
fix no sessions error

### DIFF
--- a/omniauth-qq-connect.gemspec
+++ b/omniauth-qq-connect.gemspec
@@ -16,5 +16,5 @@ Gem::Specification.new do |gem|
   gem.version       = Omniauth::Qq::Connect::VERSION
 
   gem.add_dependency 'omniauth', '~> 1.0'
-  gem.add_dependency 'omniauth-oauth2', '~> 1.0'
+  gem.add_dependency 'omniauth-oauth2', '~> 1.3.1'
 end


### PR DESCRIPTION
If user who using **rails-api** wants to omniauth as well, it would raise an error like this, `OmniAuth::NoSessionError (You must provide a session to use OmniAuth.):`,
because session middleware is detached in rails-api.

But It's no need for a user who using rails-api to use sessions except omniauth.  

This error has been fixed in omniauth-oauth2 gem.

So just using the latest one should be fine.

Regards.
